### PR TITLE
price-oracle-canister

### DIFF
--- a/src/price-oracle-canister/lib.rs
+++ b/src/price-oracle-canister/lib.rs
@@ -1,0 +1,1 @@
+//this canister will be used for HTTPS outcalls for BTC price feed 


### PR DESCRIPTION
A new canister for creating HTTPS outcalls for BTC price feed