### PR TITLE
bitcoin-transactions successful

### DIFF
--- a/src/btc-tx/src/lib.rs
+++ b/src/btc-tx/src/lib.rs
@@ -9,6 +9,7 @@ use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 mod common;
 mod ecdsa;
 mod service;
+mod p2wpkh;
 #[derive(Clone, Copy,CandidType,Deserialize)]
 pub enum Network {
     Mainnet,
@@ -26,8 +27,8 @@ pub struct BitcoinContext{
 thread_local! {
     static BTC_CONTEXT: Cell<BitcoinContext> = 
         Cell::new(BitcoinContext {
-            network: BitcoinNetwork::Testnet,
-            bitcoin_network: bitcoin::Network::Testnet,
+            network: BitcoinNetwork::Regtest,
+            bitcoin_network: bitcoin::Network::Regtest,
             key_name: "test_key_1",
         });
     }

--- a/src/btc-tx/src/service/get_balance.rs
+++ b/src/btc-tx/src/service/get_balance.rs
@@ -1,0 +1,19 @@
+use ic_cdk::{api::management_canister::bitcoin::{bitcoin_get_balance, GetBalanceRequest}, update};
+use crate::BTC_CONTEXT;
+
+#[update]
+pub async fn get_balance(address: String) -> u64 {
+    let ctx = BTC_CONTEXT.with(|ctx| ctx.get());
+
+    match bitcoin_get_balance(GetBalanceRequest {
+        address,
+        network: ctx.network,
+        min_confirmations: None,
+    }).await {
+        Ok((balance,)) => balance,
+        Err(e) => {
+            ic_cdk::println!("get_balance failed: {:?}", e);
+            0 // Or any fallback default
+        }
+    }
+}

--- a/src/btc-tx/src/service/get_current_fee_percentile.rs
+++ b/src/btc-tx/src/service/get_current_fee_percentile.rs
@@ -3,7 +3,7 @@ use ic_cdk::{api::management_canister::bitcoin::{bitcoin_get_current_fee_percent
 use crate::BTC_CONTEXT;
 
 #[update]
-pub async fn get_current_fee_percentile()->Vec<MillisatoshiPerByte>{
+pub async fn get_current_fee_percentiles()->Vec<MillisatoshiPerByte>{
     let ctx = BTC_CONTEXT.with(|ctx| ctx.get());
     let (response,) = bitcoin_get_current_fee_percentiles(GetCurrentFeePercentilesRequest{
         network : ctx.network,

--- a/src/btc-tx/src/service/mod.rs
+++ b/src/btc-tx/src/service/mod.rs
@@ -1,3 +1,5 @@
 pub mod get_p2wpkh_address;
 pub mod bitcoin_get_utxos;
 pub mod get_current_fee_percentile;
+pub mod get_balance;
+pub mod send_from_p2wpkh_address;

--- a/src/btc-tx/src/service/send_from_p2wpkh_address.rs
+++ b/src/btc-tx/src/service/send_from_p2wpkh_address.rs
@@ -1,0 +1,47 @@
+use std::str::FromStr;
+
+use bitcoin::{consensus::serialize, Address, CompressedPublicKey, PublicKey};
+use ic_cdk::{api::management_canister::bitcoin::{bitcoin_get_utxos, bitcoin_send_transaction, GetUtxosRequest, SendTransactionRequest}, trap, update};
+
+use crate::{common::{get_fee_per_byte, DerivationPath}, ecdsa::{get_ecdsa_public_key, sign_with_ecdsa}, p2wpkh, SendRequest, BTC_CONTEXT};
+
+#[update]
+pub async fn send_from_p2wpkh_address(request : SendRequest)->String{
+    let ctx = BTC_CONTEXT.with(|ctx| ctx.get());
+    if request.amount_in_satoshi ==0{
+        trap("Amount must be grater than 0 satoshi");
+    }
+
+    let dst_address = Address::from_str(&request.destination_address)
+    .unwrap()
+    .require_network(ctx.bitcoin_network)
+    .unwrap();
+    let derivation_path =DerivationPath::p2wpkh(0, 0);
+    let own_public_key = get_ecdsa_public_key(&ctx, derivation_path.to_vec_u8_path()).await;
+    let own_compressed_pub_key = CompressedPublicKey::from_slice(&own_public_key).unwrap();
+
+    let own_public_key = PublicKey::from_slice(&own_public_key).unwrap();
+    let own_address = Address::p2wpkh(&own_compressed_pub_key, ctx.bitcoin_network);
+    let (response,) = bitcoin_get_utxos(GetUtxosRequest{
+        address : own_address.to_string(),
+        network : ctx.network,
+        filter : None
+    })
+    .await
+    .unwrap();
+    let own_utxos = &response.utxos;
+
+    let fee_per_byte = get_fee_per_byte(&ctx).await;
+    let (transaction,prevouts) = p2wpkh::build_transaction(&ctx, &own_public_key, &own_address, own_utxos, &dst_address, request.amount_in_satoshi, fee_per_byte).await;
+    let signed_transactions = p2wpkh::sign_transaction(&ctx, &own_public_key, &own_address, transaction, &prevouts, derivation_path.to_vec_u8_path(), sign_with_ecdsa).await;
+
+    bitcoin_send_transaction(SendTransactionRequest{
+        network : ctx.network,
+        transaction:serialize(&signed_transactions),
+    })
+    .await
+    .unwrap();
+
+    signed_transactions.compute_txid().to_string()
+   
+}


### PR DESCRIPTION
The btc-tx canister can now send transactions to another bitcoin addresses, can receive the transactions and also can generate the p2wpkh public key for transactions.
