### PR TITLE
ic_cdk upgraded version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,8 @@ dependencies = [
  "candid",
  "hex",
  "ic-cdk",
- "ic-cdk-macros 0.18.2",
+ "ic-cdk-macros",
+ "leb128",
  "ordinals",
  "serde",
  "sha2",
@@ -486,6 +487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,43 +539,36 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.17.2"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a7344f41493cbf591f13ae9f90181076f808a83af799815c3074b19c693d2e"
+checksum = "db9cc3e0e86ee12504c749fa33793014f1f4d6956a8a70e4db595169c5f6ac26"
 dependencies = [
  "candid",
  "ic-cdk-executor",
- "ic-cdk-macros 0.17.2",
+ "ic-cdk-macros",
+ "ic-error-types",
+ "ic-management-canister-types",
  "ic0",
  "serde",
  "serde_bytes",
+ "slotmap",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "ic-cdk-executor"
-version = "0.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903057edd3d4ff4b3fe44a64eaee1ceb73f579ba29e3ded372b63d291d7c16c2"
-
-[[package]]
-name = "ic-cdk-macros"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cbaa50fa36d3e0616114becf81faa95a099e0d60948ed6978f30f1c77399fd"
+checksum = "7f3586c51b6b3809b69c79e97de172b4649f56094e8c8bc1ce2e41a29f20ed5f"
 dependencies = [
- "candid",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream",
- "syn 2.0.101",
+ "slotmap",
 ]
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.18.2"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "846b48102a4c40c0ce98ae7b7b146fbd061fea763bb7bc2363ab7e3e1e0aedd0"
+checksum = "b190cace2b141a5801252115bdc27397d47f086c928af3e917ce1da81b17e3cd"
 dependencies = [
  "candid",
  "darling",
@@ -578,10 +578,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic0"
-version = "0.23.0"
+name = "ic-error-types"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
+checksum = "bbeeb3d91aa179d6496d7293becdacedfc413c825cac79fd54ea1906f003ee55"
+dependencies = [
+ "serde",
+ "strum",
+ "strum_macros",
+]
+
+[[package]]
+name = "ic-management-canister-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98554c2d8a30c00b6bfda18062fdcef21215cad07a52d8b8b1eb3130e51bfe71"
+dependencies = [
+ "candid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic0"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8877193e1921b5fd16accb0305eb46016868cd1935b05c05eca0ec007b943272"
 
 [[package]]
 name = "ic_principal"
@@ -775,7 +797,7 @@ dependencies = [
  "candid",
  "futures",
  "ic-cdk",
- "ic-cdk-macros 0.18.2",
+ "ic-cdk-macros",
  "serde",
 ]
 
@@ -895,18 +917,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_tokenstream"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64060d864397305347a78851c51588fd283767e7e7589829e8121d65512340f1"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "serde_with"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +983,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "stacker"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1009,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "syn"
@@ -1129,7 +1170,7 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "ic-cdk",
- "ic-cdk-macros 0.18.2",
+ "ic-cdk-macros",
  "serde",
 ]
 

--- a/src/btc-tx/Cargo.toml
+++ b/src/btc-tx/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bitcoin = "0.32.6"
-ic-cdk = "0.17.2"
+ic-cdk = "0.18.5"
 ic-cdk-macros = "0.18.1"
 candid = "0.10.14"
 serde = { version = "1.0", features = ["derive"] }
@@ -18,3 +18,4 @@ sha2 = "0.10.2"
 hex = "0.4.3"
 sha3 = "0.10.8"
 ordinals = "0.0.15"
+leb128 = "0.2.5"

--- a/src/btc-tx/src/lib.rs
+++ b/src/btc-tx/src/lib.rs
@@ -4,9 +4,9 @@ use candid::{CandidType, Principal};
 use ic_cdk::{init, post_upgrade};
 
 use serde::Deserialize;
-use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
+//use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 
-
+use ic_cdk::bitcoin_canister::Network;
 
 mod common;
 mod ecdsa;
@@ -16,16 +16,17 @@ mod schnorr_api;
 mod p2tr;
 mod user_service;
 mod tags;
-#[derive(Clone, Copy,CandidType,Deserialize)]
+mod runes;
+/*#[derive(Clone, Copy,CandidType,Deserialize)]
 pub enum Network {
     Mainnet,
     Testnet,
     Regtest,
 }
-
+*/
 #[derive(Clone,Copy)]
 pub struct BitcoinContext{
-    pub network : BitcoinNetwork,
+    pub network : Network,
     pub bitcoin_network : bitcoin::Network,
     pub key_name : &'static str,
     pub schnorr_canister: Option<Principal>,
@@ -33,14 +34,14 @@ pub struct BitcoinContext{
 }
 #[derive(CandidType, Deserialize)]
 pub struct InitArgs{
-    pub network : BitcoinNetwork,
+    pub network : Network,
     pub schnorr_canister : Option<Principal>
 }
 
 thread_local! {
     static BTC_CONTEXT: Cell<BitcoinContext> = 
         Cell::new(BitcoinContext {
-            network: BitcoinNetwork::Regtest,
+            network: Network::Regtest,
             bitcoin_network: bitcoin::Network::Regtest,
             key_name: "dfx_test_key",
             schnorr_canister : None,
@@ -53,16 +54,16 @@ thread_local! {
 /*thread_local! {
     static INTENTS : RefCell<HashMap<String,(Principal,u64)>> =RefCell::new(HashMap::new());
 }*/
-fn init_upgrade(network: BitcoinNetwork ,schnorr_canister :Option<Principal>) {
+fn init_upgrade(network: Network ,schnorr_canister :Option<Principal>) {
     let key_name = match network {
-        BitcoinNetwork::Regtest => "dfx_test_key",
-        BitcoinNetwork::Mainnet | BitcoinNetwork::Testnet => "test_key_1",
+        Network::Regtest => "dfx_test_key",
+        Network::Mainnet | Network::Testnet => "test_key_1",
     };
 
     let bitcoin_network = match network {
-        BitcoinNetwork::Mainnet => bitcoin::Network::Bitcoin,
-        BitcoinNetwork::Testnet => bitcoin::Network::Testnet,
-        BitcoinNetwork::Regtest => bitcoin::Network::Regtest,
+        Network::Mainnet => bitcoin::Network::Bitcoin,
+        Network::Testnet => bitcoin::Network::Testnet,
+        Network::Regtest => bitcoin::Network::Regtest,
     };
 
     BTC_CONTEXT.with(|ctx| {

--- a/src/btc-tx/src/p2tr.rs
+++ b/src/btc-tx/src/p2tr.rs
@@ -1,35 +1,262 @@
-use bitcoin::{key::Secp256k1, taproot::{TaprootBuilder, TaprootSpendInfo}, PublicKey, ScriptBuf, XOnlyPublicKey};
+use crate::{
+    common::{build_transaction_with_fee, select_one_utxo, select_utxos_greedy, PrimaryOutput},
+    schnorr_api::mock_sign_with_schnorr,
+    BitcoinContext,
+};
+use bitcoin::{
+    blockdata::witness::Witness,
+    hashes::Hash,
+    key::XOnlyPublicKey,
+    secp256k1::{schnorr::Signature, PublicKey, Secp256k1},
+    sighash::{SighashCache, TapSighashType},
+    taproot::{ControlBlock, LeafVersion, TapLeafHash, TaprootBuilder, TaprootSpendInfo},
+    Address, AddressType, ScriptBuf, Sequence, Transaction, TxOut,
+};
+use ic_cdk::bitcoin_canister::{MillisatoshiPerByte, Utxo};
 
-
-
-
-
-
+/// Constructs the full Taproot spend info for a script-path-enabled Taproot output.
+///
+/// This function:
+/// - Converts the given internal and script leaf public keys into x-only format (as required by BIP-341)
+/// - Constructs a script leaf of the form `<script_leaf_key> OP_CHECKSIG`
+/// - Commits the script into a Taproot Merkle tree (with a single leaf)
+/// - Applies the BIP-341 tweak to the internal key to compute the output key
+///
+/// The resulting `TaprootSpendInfo` contains the tweaked output key and metadata
+/// (including the control block) required for script path spending.
 pub fn create_taproot_spend_info(
     internal_key_bytes: &[u8],
     script_key_bytes: &[u8],
-) -> Result<TaprootSpendInfo, String> {
+) -> TaprootSpendInfo {
+    // Convert the internal key to x-only format (required for Taproot tweaking).
     let internal_key = XOnlyPublicKey::from(PublicKey::from_slice(internal_key_bytes).unwrap());
-    
 
-    let spend_script = create_spend_script(script_key_bytes)?;
+    // Build the script leaf committed to in the Taproot tree.
+    // This must exactly match what will be used for script path spending.
+    let spend_script = create_spend_script(script_key_bytes);
 
+    // Construct the Taproot output:
+    // - A TaprootBuilder is used to create a Merkle tree with one leaf (our spend_script).
+    // - The tree is finalized using the internal key, producing a tweaked output key.
     let secp256k1_engine = Secp256k1::new();
-
     TaprootBuilder::new()
         .add_leaf(0, spend_script.clone())
-        .map_err(|e| format!("Failed to add leaf: {:?}", e))?
+        .expect("adding leaf should work")
         .finalize(&secp256k1_engine, internal_key)
-        .map_err(|e| format!("Failed to finalize taproot builder: {:?}", e))
+        .expect("finalizing taproot builder should work")
 }
 
-pub fn create_spend_script(script_key_bytes: &[u8]) -> Result<ScriptBuf, String> {
+/// Constructs a Taproot leaf script of the form `<script_leaf_key> OP_CHECKSIG`.
+///
+/// This script is used in Taproot script path spending. It allows spending
+/// with a single Schnorr signature corresponding to the committed script leaf key.
+///
+/// The key must match the one committed in the Taproot output's Merkle tree.
+pub fn create_spend_script(script_key_bytes: &[u8]) -> ScriptBuf {
     let script_key = XOnlyPublicKey::from(PublicKey::from_slice(script_key_bytes).unwrap());
 
-    Ok(
-        bitcoin::blockdata::script::Builder::new()
-            .push_x_only_key(&script_key)
-            .push_opcode(bitcoin::blockdata::opcodes::all::OP_CHECKSIG)
-            .into_script(),
-    )
+    bitcoin::blockdata::script::Builder::new()
+        .push_x_only_key(&script_key)
+        .push_opcode(bitcoin::blockdata::opcodes::all::OP_CHECKSIG)
+        .into_script()
+}
+
+pub enum SelectUtxosMode {
+    Greedy,
+    Single,
+}
+
+// Builds a P2TR transaction to send the given `amount` of satoshis to the
+// destination address.
+pub(crate) async fn build_transaction(
+    ctx: &BitcoinContext,
+    own_address: &Address,
+    own_utxos: &[Utxo],
+    utxos_mode: SelectUtxosMode,
+    primary_output: &PrimaryOutput,
+    fee_per_byte: MillisatoshiPerByte,
+) -> (Transaction, Vec<TxOut>) {
+    // We have a chicken-and-egg problem where we need to know the length
+    // of the transaction in order to compute its proper fee, but we need
+    // to know the proper fee in order to figure out the inputs needed for
+    // the transaction.
+    //
+    // We solve this problem iteratively. We start with a fee of zero, build
+    // and sign a transaction, see what its size is, and then update the fee,
+    // rebuild the transaction, until the fee is set to the correct amount.
+    let amount = match primary_output {
+        PrimaryOutput::Address(_, amount) => *amount,
+        PrimaryOutput::OpReturn(_) => 0,
+    };
+    let mut total_fee = 0;
+    loop {
+        let utxos_to_spend = match utxos_mode {
+            SelectUtxosMode::Greedy => select_utxos_greedy(own_utxos, amount, total_fee),
+            SelectUtxosMode::Single => select_one_utxo(own_utxos, amount, total_fee),
+        }
+        .unwrap();
+
+        let (transaction, prevouts) =
+            build_transaction_with_fee(utxos_to_spend, own_address, primary_output, total_fee)
+                .unwrap();
+
+        // Sign the transaction. In this case, we only care about the size
+        // of the signed transaction, so we use a mock signer here for
+        // efficiency.
+        //
+        // Note: it doesn't matter which particular spending path to use, key or
+        // script path, since the difference is only how the signature is
+        // computed, which is a dummy signing function in our case.
+        let signed_transaction = sign_transaction_key_spend(
+            ctx,
+            own_address,
+            transaction.clone(),
+            &prevouts,
+            vec![], // mock derivation path
+            vec![],
+            mock_sign_with_schnorr,
+        )
+        .await;
+
+        let tx_vsize = signed_transaction.vsize() as u64;
+        if (tx_vsize * fee_per_byte) / 1000 == total_fee {
+            return (transaction, prevouts);
+        } else {
+            total_fee = (tx_vsize * fee_per_byte) / 1000;
+        }
+    }
+}
+
+// Sign a P2TR script spend transaction.
+//
+// IMPORTANT: This method is for demonstration purposes only and it only
+// supports signing transactions if:
+//
+// 1. All the inputs are referencing outpoints that are owned by `own_address`.
+// 2. `own_address` is a P2TR address that includes a script.
+pub async fn sign_transaction_script_spend<SignFun, Fut>(
+    ctx: &BitcoinContext,
+    own_address: &Address,
+    mut transaction: Transaction,
+    prevouts: &[TxOut],
+    control_block: &ControlBlock,
+    script: &ScriptBuf,
+    derivation_path: Vec<Vec<u8>>,
+    signer: SignFun,
+) -> Transaction
+where
+    SignFun: Fn(String, Vec<Vec<u8>>, Option<Vec<u8>>, Vec<u8>) -> Fut,
+    Fut: std::future::Future<Output = Vec<u8>>,
+{
+    assert_eq!(own_address.address_type(), Some(AddressType::P2tr),);
+
+    for input in transaction.input.iter_mut() {
+        input.script_sig = ScriptBuf::default();
+        input.witness = Witness::default();
+        input.sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
+    }
+
+    let num_inputs = transaction.input.len();
+
+    for i in 0..num_inputs {
+        let mut sighasher = SighashCache::new(&mut transaction);
+
+        let leaf_hash = TapLeafHash::from_script(script, LeafVersion::TapScript);
+
+        let signing_data = sighasher
+            .taproot_script_spend_signature_hash(
+                i,
+                &bitcoin::sighash::Prevouts::All(prevouts),
+                leaf_hash,
+                TapSighashType::Default,
+            )
+            .expect("Failed to encode signing data")
+            .as_byte_array()
+            .to_vec();
+
+        let raw_signature = signer(
+            ctx.key_name.to_string(),
+            derivation_path.clone(),
+            None,
+            signing_data.clone(),
+        )
+        .await;
+
+        // Update the witness stack.
+
+        let witness = sighasher.witness_mut(i).unwrap();
+        witness.clear();
+        let signature = bitcoin::taproot::Signature {
+            signature: Signature::from_slice(&raw_signature).expect("failed to parse signature"),
+            sighash_type: TapSighashType::Default,
+        };
+        witness.push(signature.to_vec());
+        witness.push(script.to_bytes());
+        witness.push(control_block.serialize());
+    }
+
+    transaction
+}
+
+// Sign a P2TR key spend transaction.
+//
+// IMPORTANT: This method is for demonstration purposes only and it only
+// supports signing transactions if:
+//
+// 1. All the inputs are referencing outpoints that are owned by `own_address`.
+// 2. `own_address` is a P2TR address.
+pub async fn sign_transaction_key_spend<SignFun, Fut>(
+    ctx: &BitcoinContext,
+    own_address: &Address,
+    mut transaction: Transaction,
+    prevouts: &[TxOut],
+    derivation_path: Vec<Vec<u8>>,
+    merkle_root_hash: Vec<u8>,
+    signer: SignFun,
+) -> Transaction
+where
+    SignFun: Fn(String, Vec<Vec<u8>>, Option<Vec<u8>>, Vec<u8>) -> Fut,
+    Fut: std::future::Future<Output = Vec<u8>>,
+{
+    assert_eq!(own_address.address_type(), Some(AddressType::P2tr),);
+
+    for input in transaction.input.iter_mut() {
+        input.script_sig = ScriptBuf::default();
+        input.witness = Witness::default();
+        input.sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
+    }
+
+    let num_inputs = transaction.input.len();
+
+    for i in 0..num_inputs {
+        let mut sighasher = SighashCache::new(&mut transaction);
+
+        let signing_data = sighasher
+            .taproot_key_spend_signature_hash(
+                i,
+                &bitcoin::sighash::Prevouts::All(prevouts),
+                TapSighashType::Default,
+            )
+            .expect("Failed to encode signing data")
+            .as_byte_array()
+            .to_vec();
+
+        let raw_signature = signer(
+            ctx.key_name.to_string(),
+            derivation_path.clone(),
+            Some(merkle_root_hash.clone()),
+            signing_data.clone(),
+        )
+        .await;
+
+        // Update the witness stack.
+        let witness = sighasher.witness_mut(i).unwrap();
+        let signature = bitcoin::taproot::Signature {
+            signature: Signature::from_slice(&raw_signature).expect("failed to parse signature"),
+            sighash_type: TapSighashType::Default,
+        };
+        witness.push(signature.to_vec());
+    }
+
+    transaction
 }

--- a/src/btc-tx/src/p2wpkh.rs
+++ b/src/btc-tx/src/p2wpkh.rs
@@ -1,11 +1,12 @@
-use crate::{common::build_transaction_with_fee, ecdsa::mock_sign_with_ecdsa, BitcoinContext};
+/*use crate::{common::build_transaction_with_fee, ecdsa::mock_sign_with_ecdsa, BitcoinContext};
 use bitcoin::{
     ecdsa::Signature as BitcoinSignature,
     secp256k1::{ecdsa::Signature as SecpSignature, Message},
     sighash::{EcdsaSighashType, SighashCache},
     Address, AddressType, PublicKey, ScriptBuf, Transaction, TxOut, Witness,
 };
-use ic_cdk::api::management_canister::bitcoin::{MillisatoshiPerByte,Satoshi,Utxo};
+use ic_cdk::bitcoin_canister::{MillisatoshiPerByte, Satoshi, Utxo};
+
 // Builds a transaction to send the given `amount` of satoshis to the
 // destination address.
 pub async fn build_transaction(
@@ -110,4 +111,4 @@ where
     }
 
     transaction
-}
+}*/

--- a/src/btc-tx/src/runes.rs
+++ b/src/btc-tx/src/runes.rs
@@ -1,0 +1,190 @@
+use bitcoin::{opcodes::all::{OP_PUSHNUM_13, OP_RETURN}, script::{Builder, PushBytesBuf}, ScriptBuf};
+use leb128::write;
+
+
+
+#[allow(dead_code)]
+const MAX_DIVISIBILITY: u8 = 38;
+#[allow(dead_code)]
+const MAX_SPACERS: u32 = 0b00000111111111111111111111111111;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Tag {
+    #[allow(dead_code)]
+    Body = 0,
+    Flags = 2,
+    Rune = 4,
+    Premine = 6,
+    Cap = 8,
+    Amount = 10,
+    HeightStart = 12,
+    HeightEnd = 14,
+    OffsetStart = 16,
+    OffsetEnd = 18,
+    #[allow(dead_code)]
+    Mint = 20,
+    #[allow(dead_code)]
+    Pointer = 22,
+    #[allow(dead_code)]
+    Cenotaph = 126,
+    // Odd tags
+    Divisibility = 1,
+    Spacers = 3,
+    Symbol = 5,
+    #[allow(dead_code)]
+    Nop = 127,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Flag {
+    Etching = 0,
+    Terms = 1,
+    Turbo = 2,
+    #[allow(dead_code)]
+    Cenotaph = 127,
+}
+
+impl Flag {
+    fn mask(self) -> u128 {
+        let position = match self {
+            Flag::Etching => 0,
+            Flag::Terms => 1,
+            Flag::Turbo => 2,
+            Flag::Cenotaph => 127,
+        };
+        1 << position
+    }
+}
+
+pub fn encode_leb128(value : u64)->Vec<u8>{
+    let mut buf = Vec::new();
+    write::unsigned(&mut buf, value).unwrap();
+    buf
+}
+
+pub fn encode_rune_name(name : &str)->Result<u64,String>{
+    if name.is_empty(){
+        return Err("Rune name cannot be empty".to_string());
+    }
+
+    let mut value = 0u64;
+    for(i,ch) in name.chars().enumerate(){
+        if i >=28{
+            return Err("Rune name cannot exceed 28 characters".to_string());
+        }
+        if !ch.is_ascii_uppercase() {
+            return Err("Rune name must contain only uppercase letters A-Z".to_string());
+        }
+        let digit = (ch as u8 - b'A') as u64;
+        if i == 0{
+            value = digit;
+        }else{
+            value = value
+            .checked_add(1)
+            .and_then(|v| v.checked_mul(26))
+            .and_then(|v|v.checked_add(digit))
+            .ok_or("Rune Name Value Overflow")?;
+        }
+    }
+    Ok(value)
+}
+pub struct Etching {
+    pub divisibility: u8,
+    pub premine: u128,
+    pub rune_name: String,
+    pub symbol: Option<char>,
+    pub terms: Option<Terms>,
+    pub turbo: bool,
+    pub spacers: u32,
+}
+pub struct Terms {
+    pub amount: Option<u128>,               // Amount per mint
+    pub cap: Option<u128>,                  // Maximum number of mints
+    pub height: (Option<u64>, Option<u64>), // Absolute block height range
+    pub offset: (Option<u64>, Option<u64>), // Relative block height range
+}
+
+
+pub fn build_etching_script(etching : &Etching)->Result<ScriptBuf,String>{
+    let mut payload = Vec::new();
+    let encoded_name = encode_rune_name(&etching.rune_name)?;
+    let mut flags = Flag::Etching.mask();
+    if etching.terms.is_some(){
+        flags |=Flag::Terms.mask();
+    }
+
+    if etching.turbo{
+        flags |= Flag::Turbo.mask();
+
+    }
+
+    if etching.divisibility > 0{
+        payload.extend_from_slice(&encode_leb128(Tag::Divisibility as u64));
+        payload.extend_from_slice(&encode_leb128(etching.divisibility as u64));
+    }
+    payload.extend_from_slice(&encode_leb128(Tag::Flags as u64));
+    payload.extend_from_slice(&encode_leb128(flags as u64));
+
+    if etching.spacers > 0 {
+        payload.extend_from_slice(&encode_leb128(Tag::Spacers as u64));
+        payload.extend_from_slice(&encode_leb128(etching.spacers as u64));
+    }
+
+    // Tag 4: Rune name
+    payload.extend_from_slice(&encode_leb128(Tag::Rune as u64));
+    payload.extend_from_slice(&encode_leb128(encoded_name as u64));
+
+    // Tag 5: Symbol (odd tag)
+    if let Some(symbol) = etching.symbol {
+        payload.extend_from_slice(&encode_leb128(Tag::Symbol as u64));
+        payload.extend_from_slice(&encode_leb128(symbol as u64));
+    }
+
+    // Tag 6: Premine
+    if etching.premine > 0 {
+        payload.extend_from_slice(&encode_leb128(Tag::Premine as u64));
+        payload.extend_from_slice(&encode_leb128(etching.premine as u64));
+    }
+
+    // Add mint terms if present
+    if let Some(terms) = &etching.terms {
+        if let Some(amount) = terms.amount {
+            payload.extend_from_slice(&encode_leb128(Tag::Amount as u64));
+            payload.extend_from_slice(&encode_leb128(amount as u64));
+        }
+        if let Some(cap) = terms.cap {
+            payload.extend_from_slice(&encode_leb128(Tag::Cap as u64));
+            payload.extend_from_slice(&encode_leb128(cap as u64));
+        }
+        if let Some(start) = terms.height.0 {
+            payload.extend_from_slice(&encode_leb128(Tag::HeightStart as u64));
+            payload.extend_from_slice(&encode_leb128(start as u64));
+        }
+        if let Some(end) = terms.height.1 {
+            payload.extend_from_slice(&encode_leb128(Tag::HeightEnd as u64));
+            payload.extend_from_slice(&encode_leb128(end as u64));
+        }
+        if let Some(start) = terms.offset.0 {
+            payload.extend_from_slice(&encode_leb128(Tag::OffsetStart as u64));
+            payload.extend_from_slice(&encode_leb128(start as u64));
+        }
+        if let Some(end) = terms.offset.1 {
+            payload.extend_from_slice(&encode_leb128(Tag::OffsetEnd as u64));
+            payload.extend_from_slice(&encode_leb128(end as u64));
+        }
+    }let mut builder = Builder::new().push_opcode(OP_RETURN);
+
+    // Add OP_13 marker
+    builder = builder.push_opcode(OP_PUSHNUM_13);
+
+    // Add the entire payload as a single data push.
+    // Critical: All runestone data must be in one push after OP_13,
+    // not split into multiple chunks, per the Runes protocol specification.
+    let mut push_bytes = PushBytesBuf::new();
+    push_bytes
+        .extend_from_slice(&payload)
+        .map_err(|_| "Failed to create push bytes - payload may be too large")?;
+    builder = builder.push_slice(&push_bytes);
+
+    Ok(builder.into_script())
+}

--- a/src/btc-tx/src/service/bitcoin_get_utxos.rs
+++ b/src/btc-tx/src/service/bitcoin_get_utxos.rs
@@ -1,6 +1,6 @@
 use ic_cdk::{
-    api::management_canister::bitcoin::{bitcoin_get_utxos, GetUtxosRequest, GetUtxosResponse},
-    update,
+    //api::management_canister::bitcoin::{bitcoin_get_utxos, GetUtxosRequest, GetUtxosResponse},
+    bitcoin_canister::{bitcoin_get_utxos, GetUtxosRequest, GetUtxosResponse}, update
 };
 
 use crate::BTC_CONTEXT;
@@ -8,7 +8,7 @@ use crate::BTC_CONTEXT;
 #[update]
 pub async fn get_utxos(address: String) -> GetUtxosResponse {
     let ctx = BTC_CONTEXT.with(|ctx| ctx.get());
-    let (response,) = bitcoin_get_utxos(GetUtxosRequest {
+    let response = bitcoin_get_utxos(&GetUtxosRequest {
         address,
         network: ctx.network,
         filter: None,

--- a/src/btc-tx/src/service/get_balance.rs
+++ b/src/btc-tx/src/service/get_balance.rs
@@ -1,16 +1,18 @@
-use ic_cdk::{api::management_canister::bitcoin::{bitcoin_get_balance, GetBalanceRequest}, update};
+use ic_cdk::{bitcoin_canister::{bitcoin_get_balance, GetBalanceRequest}, update};
+
+//use ic_cdk::{api::management_canister::bitcoin::{bitcoin_get_balance, GetBalanceRequest}, update};
 use crate::BTC_CONTEXT;
 
 #[update]
 pub async fn get_balance(address: String) -> u64 {
     let ctx = BTC_CONTEXT.with(|ctx| ctx.get());
 
-    match bitcoin_get_balance(GetBalanceRequest {
+    match bitcoin_get_balance(&GetBalanceRequest {
         address,
         network: ctx.network,
         min_confirmations: None,
     }).await {
-        Ok((balance,)) => balance,
+        Ok(balance) => balance,
         Err(e) => {
             ic_cdk::println!("get_balance failed: {:?}", e);
             0 // Or any fallback default

--- a/src/btc-tx/src/service/get_current_fee_percentile.rs
+++ b/src/btc-tx/src/service/get_current_fee_percentile.rs
@@ -1,11 +1,13 @@
-use ic_cdk::{api::management_canister::bitcoin::{bitcoin_get_current_fee_percentiles, GetCurrentFeePercentilesRequest, MillisatoshiPerByte}, update};
+//use ic_cdk::{api::management_canister::bitcoin::{bitcoin_get_current_fee_percentiles, GetCurrentFeePercentilesRequest, MillisatoshiPerByte}, update};
+
+use ic_cdk::{bitcoin_canister::{bitcoin_get_current_fee_percentiles, GetCurrentFeePercentilesRequest, MillisatoshiPerByte}, update};
 
 use crate::BTC_CONTEXT;
 
 #[update]
 pub async fn get_current_fee_percentiles()->Vec<MillisatoshiPerByte>{
     let ctx = BTC_CONTEXT.with(|ctx| ctx.get());
-    let (response,) = bitcoin_get_current_fee_percentiles(GetCurrentFeePercentilesRequest{
+    let response = bitcoin_get_current_fee_percentiles(&GetCurrentFeePercentilesRequest{
         network : ctx.network,
     })
     .await

--- a/src/btc-tx/src/service/get_p2tr_script_path_address.rs
+++ b/src/btc-tx/src/service/get_p2tr_script_path_address.rs
@@ -1,4 +1,4 @@
-use bitcoin::Address;
+/*use bitcoin::Address;
 use candid::CandidType;
 use ic_cdk::update;
 use serde::Deserialize;
@@ -41,4 +41,4 @@ pub async fn get_p2tr_script_path_address() -> ResultString {
         Address::p2tr_tweaked(taproot_spend_info.output_key(), ctx.bitcoin_network).to_string();
 
     ResultString::ok(address)
-}
+}*/

--- a/src/btc-tx/src/service/intents.rs
+++ b/src/btc-tx/src/service/intents.rs
@@ -1,11 +1,11 @@
 use candid::Principal;
-use ic_cdk::{caller, query, update};
+use ic_cdk::{api::msg_caller, query, update};
 
 use crate::{INTENTS};
 
 #[update]
 fn store_intent(address :String, amount : u64){
-    let principal: Principal = caller();
+    let principal: Principal = msg_caller();
     INTENTS.with(|intents| {
         intents.borrow_mut().insert(principal, (address,amount))
     });
@@ -13,6 +13,6 @@ fn store_intent(address :String, amount : u64){
 
 #[query]
 fn get_user_intent() -> Option<(String, u64)>{
-    let principal = caller();
+    let principal = msg_caller();
     INTENTS.with(|intents| intents.borrow().get(&principal).cloned())
 }

--- a/src/btc-tx/src/service/send_from_p2wpkh_address.rs
+++ b/src/btc-tx/src/service/send_from_p2wpkh_address.rs
@@ -1,9 +1,10 @@
-use std::str::FromStr;
+/*use std::str::FromStr;
 
 use bitcoin::{consensus::serialize, Address, CompressedPublicKey, PublicKey};
-use ic_cdk::{api::management_canister::bitcoin::{bitcoin_get_utxos, bitcoin_send_transaction, GetUtxosRequest, SendTransactionRequest}, trap, update};
+use ic_cdk::{bitcoin_canister::{bitcoin_get_utxos, bitcoin_send_transaction, GetUtxosRequest, SendTransactionRequest}, trap, update};
+//use ic_cdk::{api::management_canister::bitcoin::{bitcoin_get_utxos, bitcoin_send_transaction, GetUtxosRequest, SendTransactionRequest}, trap, update};
 
-use crate::{common::{get_fee_per_byte, DerivationPath}, ecdsa::{get_ecdsa_public_key, sign_with_ecdsa}, p2wpkh, SendRequest, BTC_CONTEXT};
+use crate::{common::{get_fee_per_byte, DerivationPath}, ecdsa::{get_ecdsa_public_key, sign_with_ecdsa_fn}, p2wpkh, SendRequest, BTC_CONTEXT};
 
 #[update]
 pub async fn send_from_p2wpkh_address(request : SendRequest)->String{
@@ -22,7 +23,7 @@ pub async fn send_from_p2wpkh_address(request : SendRequest)->String{
 
     let own_public_key = PublicKey::from_slice(&own_public_key).unwrap();
     let own_address = Address::p2wpkh(&own_compressed_pub_key, ctx.bitcoin_network);
-    let (response,) = bitcoin_get_utxos(GetUtxosRequest{
+    let response = bitcoin_get_utxos(&GetUtxosRequest{
         address : own_address.to_string(),
         network : ctx.network,
         filter : None
@@ -41,13 +42,13 @@ let signed_transactions = p2wpkh::sign_transaction(
     &prevouts,
     derivation_path.to_vec_u8_path(),
     |key_name, path, hash| async move {
-        sign_with_ecdsa(key_name, path, hash)
+        sign_with_ecdsa_fn(key_name, path, hash)
             .await
             .expect("Failed to sign with ECDSA")
     },
 ).await;
 
-    bitcoin_send_transaction(SendTransactionRequest{
+    bitcoin_send_transaction(&SendTransactionRequest{
         network : ctx.network,
         transaction:serialize(&signed_transactions),
     })
@@ -56,4 +57,4 @@ let signed_transactions = p2wpkh::sign_transaction(
 
     signed_transactions.compute_txid().to_string()
    
-}
+}*/

--- a/src/btc-tx/src/tags.rs
+++ b/src/btc-tx/src/tags.rs
@@ -1,4 +1,4 @@
-use bitcoin::blockdata::script;
+/*use bitcoin::blockdata::script;
 
 use std::{convert::TryInto, mem};
 
@@ -64,4 +64,4 @@ impl Tag {
             mem::swap(&mut tmp, builder);
         }
     }
-}
+}*/

--- a/src/btc-tx/src/user_service/get_deposit_address.rs
+++ b/src/btc-tx/src/user_service/get_deposit_address.rs
@@ -1,11 +1,11 @@
 use bitcoin::{Address, CompressedPublicKey};
-use ic_cdk::{api::caller, update};
+use ic_cdk::{api::{ msg_caller}, update};
 
 use crate::{common::DerivationPath, ecdsa::get_ecdsa_public_key, user_service::util::principal_to_account, BTC_CONTEXT};
 #[update]
 pub async fn get_deposit_address()-> String{
     let ctx = BTC_CONTEXT.with(|ctx| ctx.get());
-    let principal = caller();
+    let principal = msg_caller();
     let account = principal_to_account(principal);
     let derivation_path = DerivationPath::p2wpkh(account, 0).to_vec_u8_path();
     let pub_key = get_ecdsa_public_key(&ctx, derivation_path).await;

--- a/src/price-oracle-canister/Cargo.toml
+++ b/src/price-oracle-canister/Cargo.toml
@@ -7,13 +7,12 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-ic-cdk = "0.17.2"
+ic-cdk = "0.18.5"
 ic-cdk-macros = "0.18.2"
 futures = "0.3"
 
 candid = "0.10.14"
 serde = { version = "1.0", features = ["derive"] }
-
 
 
 

--- a/src/usdb-rune-backend/Cargo.toml
+++ b/src/usdb-rune-backend/Cargo.toml
@@ -7,11 +7,10 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-ic-cdk = "0.17.2"
+ic-cdk = "0.18.5"
 ic-cdk-macros = "0.18.1"
 candid = "0.10.14"
 serde = { version = "1.0", features = ["derive"] }
-
 
 
 


### PR DESCRIPTION
## Changes
- ic_cdk 0.17.5 to ic_cdk 0.18.5
- Shifted to taproot address only 

### Important
- Because ic_cdk::api::management_canister was deprecated in older version and migrated to ic_cdk::management_canister I have changed some imports in all the files
- I also have changed schnorr signing method to updated one as older version were causing verification error
- Right now all these changes are in development stage only so current code can also be changed in the future
- Kindly keep pulling the latest commit to stay updated 